### PR TITLE
Update Patched Fix TemporaryFolder on unix-like systems does not limit access to created files

### DIFF
--- a/source-code/StringCT-java/pom.xml
+++ b/source-code/StringCT-java/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Dependency versions -->
-    <junit.version>4.12</junit.version>
+    <junit.version>4.13.1</junit.version>
     <bcprov-jdk15on.version>1.59</bcprov-jdk15on.version>
     <commons-pool2.version>2.4.2</commons-pool2.version>
     <commons-codec.version>1.10</commons-codec.version>


### PR DESCRIPTION

## Summary:
The JUnit4 test rule `TemporaryFolder` contains a local information disclosure vulnerability. On Unix like systems, the system's temporary directory is shared between all users on that system. Because of this, when files and directories are written into this directory they are, by default, readable by other users on that same system.

**PoC**
```js
public static class HasTempFolder {
    @Rule
    public TemporaryFolder folder = new TemporaryFolder();

    @Test
    public void testUsingTempFolder() throws IOException {
        folder.getRoot(); // Previous file permissions: `drwxr-xr-x`; After fix:`drwx------`
        File createdFile= folder.newFile("myfile.txt"); // unchanged/irrelevant file permissions
        File createdFolder= folder.newFolder("subfolder"); // unchanged/irrelevant file permissions
        // ...
    }
}
```

## Impact
On Unix like systems, the system's temporary directory is shared between all users on that system. Because of this, when files and directories are written into this directory they are, by default, readable by other users on that same system. This vulnerability does not allow other users to overwrite the contents of these directories or files. This is purely an information disclosure vulnerability.

CWE-200
CWE-732
**`CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:N/A:N`** CVE-2020-15250